### PR TITLE
Remove unnecessary dependencies of typescript

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,0 @@
-{
-  "presets": [
-    "next/babel",
-    "@zeit/next-typescript/babel"
-  ],
-  "plugins": [
-    ["@babel/plugin-proposal-decorators", { "legacy": true }]
-  ]
-}

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,3 @@
-const withTypescript = require("@zeit/next-typescript")
 const withCSS = require("@zeit/next-css")
 
-module.exports = withTypescript(withCSS())
+module.exports = withCSS()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1514,14 +1514,6 @@
         "postcss-loader": "3.0.0"
       }
     },
-    "@zeit/next-typescript": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@zeit/next-typescript/-/next-typescript-1.1.1.tgz",
-      "integrity": "sha512-EUcHCASftz1Bc80djkf3cKJrFgvFQyODOH1kty7ShVLLdXMaZpRLj+z7RxrCoNo1bP06w0vtXEDU0cKa0HmGgg==",
-      "requires": {
-        "@babel/preset-typescript": "7.3.3"
-      }
-    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@material-ui/icons": "^4.2.1",
     "@material-ui/styles": "^4.2.0",
     "@zeit/next-css": "^1.0.1",
-    "@zeit/next-typescript": "^1.1.1",
     "compression": "^1.7.4",
     "express": "^4.17.1",
     "immer": "^3.1.3",


### PR DESCRIPTION
Next.js v9 support detect typescript automatically, so remove dependencies of typescript.