### PR TITLE
Reduce export default

### DIFF
--- a/store/counter/reducers.ts
+++ b/store/counter/reducers.ts
@@ -7,7 +7,7 @@ import {
   ICounterState,
 } from "."
 
-export default reducerWithInitialState(CounterInitialState)
+export const countReducer = reducerWithInitialState(CounterInitialState)
   .case(
     CounterActions.increment,
     (state: Readonly<ICounterState>): ICounterState => {

--- a/store/page/reducers.ts
+++ b/store/page/reducers.ts
@@ -2,7 +2,7 @@ import produce from "immer"
 import { reducerWithInitialState } from "typescript-fsa-reducers"
 import { IPagePayload, IPageState, PageActions, PageInitialState } from "."
 
-export default reducerWithInitialState(PageInitialState).case(
+export const pageReducer = reducerWithInitialState(PageInitialState).case(
   PageActions.changePage,
   (
     state: Readonly<IPageState>,

--- a/store/reducers.ts
+++ b/store/reducers.ts
@@ -1,9 +1,9 @@
 import { combineReducers } from "redux"
-import countReducers from "./counter/reducers"
-import pageReducers from "./page/reducers"
+import { countReducer } from "./counter/reducers"
+import { pageReducer } from "./page/reducers"
 import { IInitialState } from "./states"
 
 export const combinedReducers = combineReducers<IInitialState>({
-  counter: countReducers,
-  page: pageReducers,
+  counter: countReducer,
+  page: pageReducer,
 })


### PR DESCRIPTION
## Summary

Although there is a part that currently uses `export default` , `code completion does not work` ,  `import clause is type manually` , and it is very difficult to use, so change it to `export const` instead of export default.