### PR TITLE
Hide node_modules directory

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "files.exclude": {
-    "**/.DS_Store": true
+    "**/.DS_Store": true,
+    "**/node_modules": true
   },
   "search.exclude": {
     "**/node_modules": true,


### PR DESCRIPTION
## Summary

I frequently open the node_modules directory and it is very disturbing to work, so hide it on Explorer