### PR TITLE
Support Zeit now

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-API_SERVER_URL=http://localhost:3000
+API_SERVER_URL=/

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ node_modules
 
 ## Next.js
 .next
+
+.now

--- a/now.json
+++ b/now.json
@@ -1,0 +1,7 @@
+{
+  "build": {
+    "env": {
+      "API_SERVER_URL": "@api_server_url"
+    }
+  }
+}

--- a/store/api/InputApi.ts
+++ b/store/api/InputApi.ts
@@ -5,6 +5,6 @@ import { IReduxSagaFetchPayload } from "../redux-saga"
 export const fetchInputApi = (
   payload: IReduxSagaFetchPayload
 ): Promise<InputResponseModel> => {
-  const url = `${Env.API_SERVER_URL}/api/input?value=${payload.input}`
-  return fetch(url).then<InputResponseModel>(response => response.json())
+  const url = `${Env.API_SERVER_URL}api/input?value=${payload.input}`
+  return fetch(url).then<InputResponseModel>((response) => response.json())
 }


### PR DESCRIPTION
## Summary

The other day, [Zeit's now hobby became free to use](https://zeit.co/blog/simpler-pricing) , so I was quick to support it.

* add `now.json` .
* add support for setting / in API_SERVER_URL.
