### PR TITLE
Optimizing Lint and Editor Settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,27 +16,23 @@
   },
   "[javascript]": {
     "editor.formatOnSave": true,
-    "editor.formatOnPaste": true,
     "editor.codeActionsOnSave": {
       "source.organizeImports": true
     }
   },
   "[typescript]": {
     "editor.formatOnSave": true,
-    "editor.formatOnPaste": true,
     "editor.codeActionsOnSave": {
       "source.organizeImports": true
     }
   },
   "[typescriptreact]": {
     "editor.formatOnSave": true,
-    "editor.formatOnPaste": true,
     "editor.codeActionsOnSave": {
       "source.organizeImports": true
     }
   },
   "[jsonc]": {
-    "editor.formatOnSave": true,
-    "editor.formatOnPaste": true
+    "editor.formatOnSave": true
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
     ".next": true
   },
   "files.insertFinalNewline": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "javascript.format.enable": false,
   "eslint.enable": true,
   "eslint.format.enable": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,8 @@
   },
   "search.exclude": {
     "**/node_modules": true,
-    ".next": true
+    ".next": true,
+    ".now": true
   },
   "files.insertFinalNewline": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3824,15 +3824,6 @@
         }
       }
     },
-    "eslint-plugin-prettier": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.3.tgz",
-      "integrity": "sha512-+HG5jmu/dN3ZV3T6eCD7a4BlAySdN7mLIbJYo0z1cFQuI+r2DiTJEFeF68ots93PsnrMxbzIZ2S/ieX+mkrBeQ==",
-      "dev": true,
-      "requires": {
-        "prettier-linter-helpers": "^1.0.0"
-      }
-    },
     "eslint-plugin-react": {
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.19.0.tgz",
@@ -4158,12 +4149,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
       "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
-    },
-    "fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
-      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -6788,15 +6773,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
       "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
       "dev": true
-    },
-    "prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "dev": true,
-      "requires": {
-        "fast-diff": "^1.1.2"
-      }
     },
     "private": {
       "version": "0.1.8",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "eslint": "^7.0.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-import": "^2.20.2",
-    "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.19.0",
     "prettier": "^2.0.5",
     "redux-devtools-extension": "^2.13.8",


### PR DESCRIPTION
# Update Summary

## eslint-plugin-prettier is not recommended

The official Prettier website [announced that eslint-plugin-prettier is not recommended](https://prettier.io/docs/en/integrating-with-linters.html#notes) , so removed the setting.

## Explicitly set the default formatter in VSCode

Set VSCode's built-in prettier as the [default formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode#default-formatter) .

## Disable formatting when pasting

Disabled the formatting on VSCode because it sometimes inserts an unexpected indentation when pasting, and formatting on paste is useless in most cases.
